### PR TITLE
Link FoundationExtensions statically

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -6,8 +6,8 @@
         "repositoryURL": "https://github.com/teufelaudio/FoundationExtensions.git",
         "state": {
           "branch": null,
-          "revision": "aef679bde907365943fcc8bb5ba7a03e09ec48e3",
-          "version": "0.1.12"
+          "revision": "79ebeb6b47b41f3423ac995638eba5788b373b5d",
+          "version": "0.1.17"
         }
       },
       {
@@ -24,8 +24,8 @@
         "repositoryURL": "https://github.com/teufelaudio/UIExtensions.git",
         "state": {
           "branch": null,
-          "revision": "e4abf4967db831fe9055181ad2de5a27c51b40da",
-          "version": "0.2.10"
+          "revision": "f08014d738c4a7807ca55e52cbf96068d83d2b7d",
+          "version": "0.2.16"
         }
       }
     ]

--- a/Package.swift
+++ b/Package.swift
@@ -6,14 +6,12 @@ let package = Package(
     platforms: [.macOS(.v10_15), .iOS(.v13), .tvOS(.v13), .watchOS(.v6)],
     products: [
         .library(name: "LottieExtensions", targets: ["LottieExtensions"]),
-        .library(name: "LottieExtensionsAllStatic", targets: ["LottieExtensionsAllStatic"]),
     ],
     dependencies: [
         .package(name: "Lottie", url: "https://github.com/airbnb/lottie-ios.git", from: "3.2.3"),
-        .package(name: "UIExtensions", url: "https://github.com/teufelaudio/UIExtensions.git", .upToNextMajor(from: "0.2.10"))
+        .package(name: "UIExtensions", url: "https://github.com/teufelaudio/UIExtensions.git", from: "0.2.16")
     ],
     targets: [
         .target(name: "LottieExtensions", dependencies: ["Lottie", "UIExtensions"]),
-        .target(name: "LottieExtensionsAllStatic", dependencies: ["Lottie", .product(name: "UIExtensionsAllStatic", package: "UIExtensions")])
     ]
 )

--- a/Sources/LottieExtensionsAllStatic
+++ b/Sources/LottieExtensionsAllStatic
@@ -1,1 +1,0 @@
-LottieExtensions


### PR DESCRIPTION
Making FoundationExtensions the static default.

Renamed static / dynamic, make sure that packages without any suffix are static. This unifies a inconsistency in a lot of frameworks used in our products. Also, static linking is is an attempt to fix this issue while deploying to TestFlight / AppStore:

ITMS-90334: Invalid Code Signature Identifier. The identifier "FoundationExtensions-5555494443d5626ab868338a93cce6b274e34595"
in your code signature for "FoundationExtensions" must match its Bundle Identifier "FoundationExtensions"

This fixes SwiftUI previews in Swift Packages as well.

FoundationExtensions is the default now, the dynamic product is FoundationExtensionsDynamic.